### PR TITLE
Always throw SyntaxErrors

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,6 @@ builder.add(function testPromise(test) {
 
 And nodeunitq will take care of the failure handling for you.
 
-Nodeunitq is also compatible with the [kew](https://github.com/Obvious/kew)
-library.
-
 License
 -------
 

--- a/lib/Builder.js
+++ b/lib/Builder.js
@@ -233,6 +233,7 @@ function runTestFunction(fn, test) {
       .then(function () {
         test.done()
       })
+      .done()
     }
   } catch (e) {
     _printError(test, e)
@@ -246,6 +247,15 @@ function _isPromiseLike(obj) {
 
 function _printError(test, e) {
   test.ok(false, _getErrorString(e))
+  if (e instanceof SyntaxError) {
+    // V8 SyntaxErrors do not contain the full error context. The NodeJS crash handlers
+    // have some special logic to work around this bug. See this thread for more info:
+    // https://github.com/nodejs/node-v0.x-archive/issues/3452#issuecomment-26013991
+    //
+    // For syntax errors in development, we re-throw the exception. This crashes
+    // the server but emits better error info.
+    throw e
+  }
 }
 
 function _getErrorString(e) {

--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
   },
   "main": "nodeunitq.js",
   "dependencies": {
-    "q": "1.0.0"
+    "q": "^1.0.0"
   },
   "devDependencies": {
-    "nodeunit": "0.9.1"
+    "nodeunit": "^0.9.1"
   },
   "scripts": {
     "test": "./node_modules/.bin/nodeunit test"

--- a/test/base.js
+++ b/test/base.js
@@ -1,6 +1,6 @@
 // Copyright 2013. The Obvious Corporation.
 
-var Q = require('Q')
+var Q = require('q')
 var Builder = require('../nodeunitq').Builder
 
 exports.testErrors = function (test) {

--- a/test/environments.js
+++ b/test/environments.js
@@ -1,6 +1,6 @@
 // Copyright 2014. The Obvious Corporation.
 
-var Q = require('Q')
+var Q = require('q')
 var Builder = require('../nodeunitq').Builder
 var util = require('util')
 


### PR DESCRIPTION
Hello @nicks, 

Please review the following commits I made in branch 'nicks/syntax'.

b0a8af8cb2d7834557cf90fb6dfcecb226d8b049 (2016-06-06 13:58:12 -0400)
Always throw SyntaxErrors

R=@nicks